### PR TITLE
Add parameter to configure Contour loadBalancerPolicy for routes which point to Paralus

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -18,6 +18,14 @@ parameters:
 
     openshift_compatibility: false
 
+    httpProxyParalus:
+      # A valid Contour `loadBalancerPolicy`, cf.
+      # https://projectcontour.io/docs/1.24/config/request-routing/#load-balancing-strategy.
+      # The contents of this field are applied to each entry of the `console`
+      # HTTPProxy `spec.routes` which has the Paralus service as the backend.
+      loadBalancerPolicy:
+        strategy: Cookie
+
     db_args:
       # Default setting in Helm chart
       sslmode: disable

--- a/class/paralus.yml
+++ b/class/paralus.yml
@@ -34,5 +34,8 @@ parameters:
           path: paralus/10_helmchart/ztka/templates
           filter: postprocess/patch_ingress.jsonnet
         - type: jsonnet
+          path: paralus/10_helmchart/ztka/templates
+          filter: postprocess/patch_httpproxy.jsonnet
+        - type: jsonnet
           path: paralus/10_helmchart/ztka/charts/kratos/templates
           filter: postprocess/patch_kratos.jsonnet

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -62,6 +62,28 @@ If this parameter is set to true and the Helm chart is configured to generate `I
 
 NOTE: OpenShift's ingress router must be configured to allow wildcard routes for the component to work on OpenShift.
 
+== `httpProxyParalus`
+
+This parameter contains customizations to apply  to the Contour `HTTPProxy` object for the Paralus control plane.
+
+=== `httpProxyParalus.loadBalancerPolicy`
+
+[horizontal]
+type:: object
+default::
++
+[source,yaml]
+----
+strategy: Cookie
+----
+
+The component expects that this field contains a valid Contour `loadBalancerPolicy`.
+See the https://projectcontour.io/docs/1.24/config/request-routing/#load-balancing-strategy[upstream documentation] for supported options.
+
+The component will apply the contents of this field as field `loadBalancerPolicy` for each entry in `spec.routes` of the `console` Contour `HTTPProxy` which points to the Paralus service.
+
+By default, the component configures sticky sessions for the Paralus service.
+
 == `helm_values`
 
 [horizontal]

--- a/postprocess/patch_httpproxy.jsonnet
+++ b/postprocess/patch_httpproxy.jsonnet
@@ -1,0 +1,30 @@
+local com = import 'lib/commodore.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local inv = com.inventory();
+local params = inv.parameters.paralus;
+
+local manifests_dir = std.extVar('output_path');
+
+local fixupHTTPProxyConsole(obj) =
+  std.prune(obj) {
+    spec+: {
+      routes: [
+        if r.services[0].name == 'paralus' then
+          r {
+            loadBalancerPolicy: params.httpProxyParalus.loadBalancerPolicy,
+          }
+        else
+          r
+        for r in super.routes
+      ],
+    },
+  };
+
+local fixupManifests(obj) =
+  if obj.kind == 'HTTPProxy' && obj.metadata.name == 'console' then
+    fixupHTTPProxyConsole(obj)
+  else
+    obj;
+
+com.fixupDir(manifests_dir, fixupManifests)

--- a/tests/golden/defaults/paralus/paralus/10_helmchart/ztka/templates/httpproxy-console.yaml
+++ b/tests/golden/defaults/paralus/paralus/10_helmchart/ztka/templates/httpproxy-console.yaml
@@ -6,21 +6,29 @@ spec:
   routes:
     - conditions:
         - prefix: /auth
+      loadBalancerPolicy:
+        strategy: Cookie
       services:
         - name: paralus
           port: 11000
     - conditions:
         - prefix: /event
+      loadBalancerPolicy:
+        strategy: Cookie
       services:
         - name: paralus
           port: 11000
     - conditions:
         - prefix: /infra
+      loadBalancerPolicy:
+        strategy: Cookie
       services:
         - name: paralus
           port: 11000
     - conditions:
         - prefix: /v2/sentry
+      loadBalancerPolicy:
+        strategy: Cookie
       services:
         - name: paralus
           port: 11000


### PR DESCRIPTION
By default, we configure those routes to have sticky client sessions to workaround the lack of multi-replica session management in the Paralus service.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
